### PR TITLE
This commit implements the final round of layout adjustments and a st…

### DIFF
--- a/script.js
+++ b/script.js
@@ -227,7 +227,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const logoHtml = `<div class="logo-column-main"><img src="Media/Logo_main-min.png" alt="Logo"></div>`;
 
         // Use `groups-view` as the main class for the 3-column layout
-        container.innerHTML = `<div class="groups-view">${leftColumnHtml}${logoHtml}${rightColumnHtml}</div>`;
+        container.innerHTML = `<div id="layout-area"><div class="groups-view">${leftColumnHtml}${logoHtml}${rightColumnHtml}</div></div>`;
         initCardGradients();
     }
 
@@ -296,7 +296,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function renderBracketCanvas(container) {
-        let html = '<div class="bracket-view">'; // This will be a position: relative container
+        let html = '<div id="layout-area"><div class="bracket-view">'; // This will be a position: relative container
 
         // --- Absolutely Positioned Columns ---
 
@@ -329,7 +329,7 @@ document.addEventListener('DOMContentLoaded', () => {
         html += renderMatch('third-place', 'third-match');
         html += '</div>';
 
-        html += '</div>'; // Close .bracket-view
+        html += '</div></div>'; // Close .bracket-view and #layout-area
         container.innerHTML = html;
     }
 

--- a/style.css
+++ b/style.css
@@ -46,8 +46,17 @@ body {
     transform-origin: center;
     position: relative;
     box-sizing: border-box;
-    overflow: hidden; /* Ensure background scaling doesn't bleed out */
+    overflow: visible; /* Allow content to spill out for positioning */
     z-index: 10; /* Ensure canvas is on top of decorations */
+}
+
+#layout-area {
+    position: absolute;
+    width: 110%;
+    height: 100%;
+    left: 50%;
+    top: 0;
+    transform: translateX(-50%);
 }
 
 /* --- SAVE BUTTON --- */
@@ -223,25 +232,25 @@ body {
 }
 
 .bracket-qf-column {
-    left: 0;
+    left: -5%;
     top: 48%;
     transform: translateY(-50%);
 }
 
 .bracket-sf-column {
     left: 48%;
-    top: 45%;
+    top: 42%;
     transform: translate(-50%, -50%);
 }
 
 .bracket-final-group {
-    right: 0;
+    right: -5%;
     top: 60px; /* Position from top */
     align-items: flex-end; /* Align content of this group to the right */
 }
 
 .bracket-third-place-group {
-    left: 55%;
+    left: 60%;
     bottom: 40px; /* Position from bottom */
     transform: translateX(-50%);
     align-items: center; /* Align content of this group to the center */
@@ -330,7 +339,7 @@ body {
 }
 
 .third-match {
-    margin-top: 10px; /* Spacing from the final match */
+    margin-top: 5px; /* Spacing from the final match */
 }
 
 .bracket-view .player-slot {


### PR DESCRIPTION
…ructural change to resolve clipping issues.

- **Canvas Restructure:** A new, wider `#layout-area` div has been introduced inside the main canvas. The `#canvas` overflow is set to 'visible', allowing elements inside the layout area to be positioned outside the original canvas bounds without being clipped. This was necessary to fulfill requests to move elements further to the sides.

- **Playoffs View:**
    - Quarterfinals and Grand Final columns are moved further to the left and right respectively, into the new overflow area.
    - Semifinals are moved higher.
    - The 3rd Place Match group is moved to the right, and the gap between its header and match box is further reduced.

- **Groups View:**
    - The structural change to use a wider layout area allows the group columns to be positioned further apart, resolving the user's recurring request.